### PR TITLE
feat: add paragon theme support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,4 +49,4 @@ Files this package must make available
     :alt: favicon
     :width: 32px
 
-``/paragon/fonts.scss``, ``/paragon/_variables.scss``, ``/paragon/_overrides.scss``  A SASS theme for `@edx/paragon <https://github.com/edx/paragon>`_. Theming documentation in Paragon is coming soon. In the meantime, you can start a theme by the contents of `_variables.scss (after line 7) <https://github.com/edx/paragon/blob/master/scss/core/_variables.scss#L7-L1046>`_ file from the Paragon repository into this file.
+``/paragon/theme.js``, ``/paragon/fonts.scss``, ``/paragon/_variables.scss``, ``/paragon/_overrides.scss``  A CSS-in-JS and SASS theme for `@edx/paragon <https://github.com/edx/paragon>`_. Theming documentation in Paragon is coming soon. In the meantime, you can start a theme by the contents of `_variables.scss (after line 7) <https://github.com/edx/paragon/blob/master/scss/core/_variables.scss#L7-L1046>`_ file from the Paragon repository into this file.

--- a/paragon/theme.js
+++ b/paragon/theme.js
@@ -1,0 +1,10 @@
+// The theme.js for Paragon. The structure of this object follows the
+// theme specification found here: https://system-ui.com/theme/. Theme values
+// not defined here will fallback to their Paragon defaults.
+
+const theme = {
+
+};
+
+export default theme;
+

--- a/paragon/theme.js
+++ b/paragon/theme.js
@@ -2,9 +2,10 @@
 // theme specification found here: https://system-ui.com/theme/. Theme values
 // not defined here will fallback to their Paragon defaults.
 
-const theme = {
+const applyTheme = (oldTheme) => {
+  const theme = { ...oldTheme };
+  return theme;
+}
 
-};
-
-export default theme;
+export default applyTheme;
 


### PR DESCRIPTION
Building on Adam's PR, this set up an applyTheme method in theme.js that copies variables over to from scss to the js
*note:* there are currently no values to move, but the export needs to be a function in order to match with the edx.org brand)