### PR TITLE
fix: Update the npm release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,17 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Setup Nodejs Env
-        run: echo "NODE_VER=`cat .nvmrc`" >> $GITHUB_ENV
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ env.NODE_VER }}
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.OPENEDX_NPM_RELEASE_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.OPENEDX_NPM_RELEASE_NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.OPENEDX_SEMANTIC_RELEASE_NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Marking this as a fix so that it publishes a new version and exercises
the changes.  We change the names for the secrets to be more generic
than NPM because they are being used for semantic release of other
libraries to other package systems as well.
