### PR TITLE
fix: build tokens to paragon/build and copy into dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 node_modules
 dist
+paragon/build

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 .PHONY: build build-tokens build-scss dist clean
-build: clean build-tokens build-scss
+build: clean dist build-tokens build-scss
 	cp *.svg *.png *.ico dist/
-	cp -r paragon/images dist/paragon/
+	cp -r paragon/{build,images} dist/paragon/
 
 dist:
 	mkdir -p dist/paragon
 
-build-tokens: dist
-	paragon build-tokens --source ./paragon/tokens/ --build-dir ./dist/paragon/build -t light
+build-tokens:
+	paragon build-tokens --source ./paragon/tokens/ --build-dir ./paragon/build -t light
 
 build-scss: dist
-	paragon build-scss --corePath ./paragon/core.scss --themesPath ./dist/paragon/build/themes --source
+	paragon build-scss --corePath ./paragon/core.scss --themesPath ./paragon/build/themes --source
 
 clean:
-	rm -rf dist
+	rm -rf dist paragon/build


### PR DESCRIPTION
### Description

Partially reverts the previous commit which tried to have `build-tokens` output directly to `dist/paragon/build`. That broke the SCSS compilation because `paragon/core.scss` references `./build/core/variables` relative to itself, so the tokens need to exist at `paragon/build/` at compile time.

This restores `build-tokens` output to `paragon/build/`, restores the `.gitignore` entry for it, and copies the built tokens into `dist/paragon/build/` along with `paragon/images/` as a post-build step.

### LLM usage notice

Built with assistance from Claude.