### PR TITLE
fix: avoid brace expansion in Makefile for CI compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build build-tokens build-scss dist clean
 build: clean dist build-tokens build-scss
 	cp *.svg *.png *.ico dist/
-	cp -r paragon/{build,images} dist/paragon/
+	cp -r paragon/build paragon/images dist/paragon/
 
 dist:
 	mkdir -p dist/paragon


### PR DESCRIPTION
### Description

The Makefile used bash-style brace expansion (`{build,images}`) to copy paragon directories into `dist/`. Since `make` invokes `/bin/sh` by default, this doesn't work in CI environments where `/bin/sh` is not bash.

Replaced with explicit arguments to `cp -r`, which is portable across all POSIX shells.

### LLM usage notice

Built with assistance from Claude.